### PR TITLE
Update Clickaway

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,25 @@ Vue.use(Dropdown)
 ```
 
 ## Slots
-Customise button
+#####button
+Replaces the button entirely
+``` html
+<dropdown ref="dropdown">
+    <button slot="button" class="flex items-center" @click="handleClick">
+        <div class="mr-2">Menu</div>
+        <i class="fas fa-caret-down"></i>
+    </button>
+</dropdown>
+```
+Note: if you replace the button entirely you will need to manually handle the toggling of the dropdown via a ref to the dropdown component e.g. `this.$refs.dropdown.toggle()`
+
+#####button-content
+Replaces the content inside the button
 ``` html
 <dropdown>
-    <template slot="button">
-        <div class="flex items-center">
-            <div class="mr-2">Menu</div>
-            <i class="fas fa-caret-down"></i>
-        </div>
-    </template>
+    <div slot="button-content" class="p-2">
+        <i class="fas fa-ellipsis-h"></i>
+    </div>
 </dropdown>
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@codinglabs/vue-dropdown",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -18,15 +18,15 @@
       }
     },
     "vue": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.11.tgz",
-      "integrity": "sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ==",
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.12.tgz",
+      "integrity": "sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg==",
       "dev": true
     },
-    "vue-clickaway": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/vue-clickaway/-/vue-clickaway-2.2.2.tgz",
-      "integrity": "sha512-25SpjXKetL06GLYoLoC8pqAV6Cur9cQ//2g35GRFBV4FgoljbZZjTINR8g2NuVXXDMLSUXaKx5dutgO4PaDE7A==",
+    "vue-clickaway2": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/vue-clickaway2/-/vue-clickaway2-2.3.2.tgz",
+      "integrity": "sha512-Zx8gAeTy5QNk9rROYk7NpnwL9gx0NBMmYokd7vylQ9c9DhPWaEV+0lsz75wXS5wjQ4xM+nzzGcGf/5/C1FZikA==",
       "requires": {
         "loose-envify": "^1.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "url": "git+https://github.com/codinglabsau/vue-dropdown.git"
   },
   "dependencies": {
-    "vue-clickaway": "^2.2.2"
+    "vue-clickaway2": "^2.3.2"
   },
   "devDependencies": {
-    "vue": "^2.6.11"
+    "vue": "^2.6.12"
   }
 }

--- a/src/Dropdown.vue
+++ b/src/Dropdown.vue
@@ -1,12 +1,14 @@
 <template>
   <div class="vue-dropdown relative inline-block text-left">
-    <div>
+    <div v-on-clickaway="hide">
       <slot name="button">
-        <button @click="toggle" v-on-clickaway="hide" @keydown.esc="hide" type="button" :class="textClasses">
-          <span v-html="text" />
-          <svg class="-mr-1 ml-2 h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
-            <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd"/>
-          </svg>
+        <button @click="toggle" @keydown.esc="hide" type="button" :class="textClasses">
+          <slot name="button-content">
+            <span v-html="text" />
+            <svg class="-mr-1 ml-2 h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
+              <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd"/>
+            </svg>
+          </slot>
         </button>
       </slot>
     </div>
@@ -22,10 +24,12 @@
 </template>
 
 <script>
-  import { mixin as clickaway } from 'vue-clickaway'
+  import { directive as onClickaway } from 'vue-clickaway2'
 
   export default {
-    mixins: [clickaway],
+    directives: {
+      onClickaway
+    },
 
     props: {
       text: {


### PR DESCRIPTION
Main change was to update to the new version of the clickaway plugin.

Also added an extra slot named `button-content` to control the content of the button without having to replace the entire button and have to toggle the dropdown manually via a ref.